### PR TITLE
Bug/roi fill opacity

### DIFF
--- a/src/View/mainpage/DicomView.py
+++ b/src/View/mainpage/DicomView.py
@@ -217,7 +217,8 @@ class DicomView(QtWidgets.QWidget):
                 stream.close()
             roi_opacity = int((roi_opacity / 100) * 255)
             color.setAlpha(roi_opacity)
-            pen = self.get_qpen(color, roi_line, line_width)
+            pen_color = QtGui.QColor(color.red(), color.green(), color.blue())
+            pen = self.get_qpen(pen_color, roi_line, line_width)
             for i in range(len(polygons)):
                 self.scene.addPolygon(polygons[i], pen, QtGui.QBrush(color))
 

--- a/src/View/mainpage/StructureTab.py
+++ b/src/View/mainpage/StructureTab.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from random import randint, seed
 
 from PySide6 import QtWidgets, QtGui, QtCore
+from PySide6.QtCore import Qt
 
 from src.Controller.ROIOptionsController import ROIDelOption, ROIDrawOption
 from src.Model import ImageLoading
@@ -23,7 +24,6 @@ class StructureTab(QtWidgets.QWidget):
         self.rois = self.patient_dict_container.get("rois")
         self.color_dict = self.init_color_roi()
         self.patient_dict_container.set("roi_color_dict", self.color_dict)
-
         self.structure_tab_layout = QtWidgets.QVBoxLayout()
 
         self.roi_delete_handler = ROIDelOption(self.structure_modified)
@@ -67,7 +67,6 @@ class StructureTab(QtWidgets.QWidget):
         :return: Dictionary where the key is the ROI number and the value a QColor object.
         """
         roi_color = dict()
-
         roi_contour_info = self.patient_dict_container.get("dict_dicom_tree_rtss")['ROI Contour Sequence']
 
         if len(roi_contour_info) > 0:
@@ -77,7 +76,6 @@ class StructureTab(QtWidgets.QWidget):
                 # we get the ROI number 'roi_id' by using the member 'list_roi_numbers'
                 id = item.split()[1]
                 roi_id = self.patient_dict_container.get("list_roi_numbers")[int(id)]
-
                 if 'ROI Display Color' in roi_contour_info[item]:
                     RGB_list = roi_contour_info[item]['ROI Display Color'][0]
                     red = RGB_list[0]
@@ -154,7 +152,11 @@ class StructureTab(QtWidgets.QWidget):
         row = 0
         for roi_id, roi_dict in self.rois.items():
             # Creates a widget representing each ROI
-            structure = StructureWidget(roi_id, self.color_dict[roi_id], roi_dict['name'], self)
+            color = self.color_dict[roi_id]
+            color.setAlpha(255)
+            structure = StructureWidget(roi_id, color, roi_dict['name'], self)
+            if roi_id in self.patient_dict_container.get("selected_rois"):
+                structure.checkbox.setChecked(Qt.Checked)
             structure.structure_renamed.connect(self.structure_modified)
             self.layout_content.addWidget(structure)
             row += 1

--- a/src/View/mainpage/StructureWidget.py
+++ b/src/View/mainpage/StructureWidget.py
@@ -29,21 +29,21 @@ class StructureWidget(QtWidgets.QWidget):
         self.layout.addWidget(color_square_label)
 
         # Create checkbox
-        checkbox = QtWidgets.QCheckBox()
-        checkbox.setFocusPolicy(QtCore.Qt.NoFocus)
-        checkbox.clicked.connect(self.checkbox_clicked)
+        self.checkbox = QtWidgets.QCheckBox()
+        self.checkbox.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.checkbox.clicked.connect(self.checkbox_clicked)
         if text in structure_tab.standard_organ_names or text in structure_tab.standard_volume_names:
             self.standard_name = True
-            checkbox.setStyleSheet("font: 10pt \"Laksaman\";")
+            self.checkbox.setStyleSheet("font: 10pt \"Laksaman\";")
         else:
             self.standard_name = False
-            checkbox.setStyleSheet("font: 10pt \"Laksaman\"; color: red;")
+            self.checkbox.setStyleSheet("font: 10pt \"Laksaman\"; color: red;")
         for item in structure_tab.standard_volume_names:  # Any suffix number will still be considered standard.
             if text.startswith(item):
                 self.standard_name = True
-                checkbox.setStyleSheet("font: 10pt \"Laksaman\";")
-        checkbox.setText(text)
-        self.layout.addWidget(checkbox)
+                self.checkbox.setStyleSheet("font: 10pt \"Laksaman\";")
+        self.checkbox.setText(text)
+        self.layout.addWidget(self.checkbox)
 
         self.layout.setAlignment(Qt.AlignLeft)
 


### PR DESCRIPTION
- Display ROI borderline using QPen, even when roi_line_fill is set to 0% in Add-on option
- Retain ticks and background color of previously checked boxes after Structure Tab is updated
- Remove duplicates in roi_id list in patient_dict_container when roi_line_fill set to > 0% to avoid permanent display of original specification